### PR TITLE
Correct ElasticExport autostart

### DIFF
--- a/src/main/java/com/nccgroup/loggerplusplus/exports/ElasticExporter.java
+++ b/src/main/java/com/nccgroup/loggerplusplus/exports/ElasticExporter.java
@@ -49,17 +49,17 @@ public class ElasticExporter extends AutomaticLogExporter implements ExportPanel
         super(exportController, preferences);
         this.fields = new ArrayList<>(preferences.getSetting(Globals.PREF_PREVIOUS_ELASTIC_FIELDS));
         executorService = Executors.newScheduledThreadPool(1);
-        controlPanel = new ElasticExporterControlPanel(this);
 
         if ((boolean) preferences.getSetting(Globals.PREF_ELASTIC_AUTOSTART_GLOBAL)
                 || (boolean) preferences.getSetting(Globals.PREF_ELASTIC_AUTOSTART_PROJECT)) {
             try {
-                setup();
+                this.exportController.enableExporter(this);
             } catch (Exception e) {
                 exportController.getLoggerPlusPlus().getLoggingController().logError(
                         String.format("Could not automatically start elastic exporter: %s", e.getMessage()));
             }
         }
+        controlPanel = new ElasticExporterControlPanel(this);
     }
 
     @Override

--- a/src/main/java/com/nccgroup/loggerplusplus/exports/ElasticExporterControlPanel.java
+++ b/src/main/java/com/nccgroup/loggerplusplus/exports/ElasticExporterControlPanel.java
@@ -78,6 +78,13 @@ public class ElasticExporterControlPanel extends JPanel {
             }
         });
 
+        if (isExporterEnabled()){
+            exportButton.setSelected(true);
+            exportButton.setText(STOP_TEXT);
+            showConfigDialogButton.setEnabled(false);
+        }
+
+
         this.add(PanelBuilder.build(new JComponent[][]{
                 new JComponent[]{showConfigDialogButton},
                 new JComponent[]{exportButton}
@@ -96,6 +103,10 @@ public class ElasticExporterControlPanel extends JPanel {
 
     private void disableExporter() throws Exception {
         this.elasticExporter.getExportController().disableExporter(this.elasticExporter);
+    }
+
+    private boolean isExporterEnabled() {
+        return this.elasticExporter.getExportController().getEnabledExporters().contains(this.elasticExporter);
     }
 
 }


### PR DESCRIPTION
Hi,
I was trying to use the Elastic Exporter to store an intercepted request to an ElasticSearch instance. I found multiples issues : 

- Firstly, the Logger++ version of the BAppStore (v3.18) can't export to Elasticsearch.

- Secondly, the latest version of the AutoStart option of the ElasticExporter doesn't actually register the exporter, it only sets up it.

I've provided the fixes in this pull request. I also added a condition to display the exporter state when BurpSuite start.
