### PR TITLE
Improve log processor to always get final request and response.

### DIFF
--- a/src/main/java/com/nccgroup/loggerplusplus/exports/HarSerializer.java
+++ b/src/main/java/com/nccgroup/loggerplusplus/exports/HarSerializer.java
@@ -112,8 +112,8 @@ public class HarSerializer extends TypeAdapter<List<LogEntry>> {
                 writer.endObject(); // end postData object
             }
 
-            writer.name("headersSize").value(logEntry.requestResponse.getRequest().length - logEntry.requestLength);
-            writer.name("bodySize").value(logEntry.requestLength);
+            writer.name("headersSize").value(logEntry.requestResponse.getRequest().length - logEntry.requestBodyLength);
+            writer.name("bodySize").value(logEntry.requestBodyLength);
 
             writer.endObject(); // end request object
 
@@ -150,11 +150,11 @@ public class HarSerializer extends TypeAdapter<List<LogEntry>> {
             writer.endArray(); // end response headers array
 
             writer.name("redirectURL").value(String.valueOf(logEntry.getValueByKey(LogEntryField.REDIRECT_URL)));
-            writer.name("headersSize").value(logEntry.requestResponse.getResponse().length - logEntry.responseLength);
-            writer.name("bodySize").value(logEntry.responseLength);
+            writer.name("headersSize").value(logEntry.requestResponse.getResponse().length - logEntry.responseBodyLength);
+            writer.name("bodySize").value(logEntry.responseBodyLength);
 
             writer.name("content").beginObject(); // start content object
-            writer.name("size").value(logEntry.responseLength);
+            writer.name("size").value(logEntry.responseBodyLength);
             writer.name("mimeType").value(logEntry.responseMimeType);
             writer.name("text").value(String.valueOf(logEntry.getValueByKey(LogEntryField.RESPONSE_BODY)));
             writer.endObject(); //end content object

--- a/src/main/java/com/nccgroup/loggerplusplus/logentry/LogEntry.java
+++ b/src/main/java/com/nccgroup/loggerplusplus/logentry/LogEntry.java
@@ -24,6 +24,7 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.*;
 import java.util.regex.Matcher;
@@ -59,13 +60,13 @@ public class LogEntry {
 	public String requestContentType = "";
 	public String protocol = "";
 	public int targetPort = -1;
-	public int requestLength = -1;
+	public int requestBodyLength = -1;
 	public String clientIP = "";
 	public boolean hasSetCookies = false;
 	public String formattedResponseTime = "";
 	public String responseMimeType = "";
 	public String responseInferredMimeType = "";
-	public int responseLength = -1;
+	public int responseBodyLength = -1;
 	public String responseContentType = "";
 	public boolean complete = false;
 	public CookieJarStatus usesCookieJar = CookieJarStatus.NO;
@@ -194,17 +195,16 @@ public class LogEntry {
 			this.urlExtension = "";
 		}
 
-		this.requestLength = requestResponse.getRequest().length - tempAnalyzedReq.getBodyOffset();
-		this.hasBodyParam = requestLength > 0;
+		this.requestBodyLength = requestResponse.getRequest().length - tempAnalyzedReq.getBodyOffset();
+		this.hasBodyParam = requestBodyLength > 0;
 		this.params = this.url.getQuery() != null || this.hasBodyParam;
 		this.hasCookieParam = false;
 
 		// reading request headers like a boss!
 		for (String item : requestHeaders) {
-			if (item.indexOf(":") >= 0) {
+			if (item.contains(":")) {
 				String[] headerItem = item.split(":\\s", 2);
-				headerItem[0] = headerItem[0].toLowerCase();
-				if (headerItem[0].equals("cookie")) {
+				if (headerItem[0].equalsIgnoreCase("cookie")) {
 					this.sentCookies = headerItem[1];
 					if (!this.sentCookies.isEmpty()) {
 						this.hasCookieParam = true;
@@ -314,9 +314,17 @@ public class LogEntry {
 		reflectedParameters = new ArrayList<>();
 		IResponseInfo tempAnalyzedResp = LoggerPlusPlus.callbacks.getHelpers()
 				.analyzeResponse(requestResponse.getResponse());
-		String strFullResponse = new String(requestResponse.getResponse());
-		this.responseLength = requestResponse.getResponse().length - tempAnalyzedResp.getBodyOffset();
 
+		this.responseStatus = tempAnalyzedResp.getStatusCode();
+		this.responseBodyLength = requestResponse.getResponse().length - tempAnalyzedResp.getBodyOffset();
+		this.responseMimeType = tempAnalyzedResp.getStatedMimeType();
+		this.responseInferredMimeType = tempAnalyzedResp.getInferredMimeType();
+
+		/**************************************
+		 ************HEADER PROCESSING*********
+		 **************************************/
+
+		//Fancy handling to combine duplicate headers into CSVs.
 		Map<String, String> headers = tempAnalyzedResp.getHeaders().stream().filter(s -> s.contains(":"))
 				.collect(Collectors.toMap(s -> {
 					String[] split = s.split(": ", 2);
@@ -333,7 +341,7 @@ public class LogEntry {
 				}, () -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER)));
 
 		responseHeaders = tempAnalyzedResp.getHeaders();
-		this.responseStatus = tempAnalyzedResp.getStatusCode();
+
 		if (headers.containsKey("Location")) {
 			this.redirectURL = headers.get("Location");
 		}
@@ -343,31 +351,16 @@ public class LogEntry {
 		this.responseStatusText = httpStatusTokens[httpStatusTokens.length - 1];
 		this.responseHttpVersion = httpStatusTokens[0];
 
-		this.responseMimeType = tempAnalyzedResp.getStatedMimeType();
-		this.responseInferredMimeType = tempAnalyzedResp.getInferredMimeType();
-		for (ICookie cookieItem : tempAnalyzedResp.getCookies()) {
-			this.newCookies += cookieItem.getName() + "=" + cookieItem.getValue() + "; ";
-		}
-		this.hasSetCookies = !newCookies.isEmpty();
-
 		if (headers.containsKey("content-type")) {
 			this.responseContentType = headers.get("content-type");
 		}
 
-		Matcher titleMatcher = Globals.HTML_TITLE_PATTERN.matcher(strFullResponse);
-		if (titleMatcher.find()) {
-			this.title = titleMatcher.group(1);
+		//Cookies
+		for (ICookie cookieItem : tempAnalyzedResp.getCookies()) {
+			this.newCookies += cookieItem.getName() + "=" + cookieItem.getValue() + "; "; //TODO convert to map, and add filter support for maps
 		}
+		this.hasSetCookies = !newCookies.isEmpty();
 
-		String responseBody = new String(requestResponse.getResponse())
-				.substring(requestResponse.getResponse().length - responseLength);
-
-		ReflectionController reflectionController = LoggerPlusPlus.instance.getReflectionController();
-		reflectedParameters = tempParameters.parallelStream()
-				.filter(iParameter -> !reflectionController.isParameterFiltered(iParameter)
-						&& reflectionController.validReflection(responseBody, iParameter))
-				.map(IParameter::getName).collect(Collectors.toList());
-		tempParameters = null; // We're done with these. Allow them to be cleaned.
 
 		if (this.responseDateTime == null) {
 			// If it didn't have an arrival time set, parse the response for it.
@@ -393,6 +386,47 @@ public class LogEntry {
 		if (requestDateTime != null && responseDateTime != null) {
 			this.requestResponseDelay = (int) (responseDateTime.getTime() - requestDateTime.getTime());
 		}
+
+		/**************************************
+		 *************BODY PROCESSING**********
+		 **************************************/
+
+		Long maxRespSize = ((Integer) LoggerPlusPlus.instance.getPreferencesController().getPreferences().getSetting(Globals.PREF_MAX_RESP_SIZE)) * 1000000L;
+
+		if (responseBodyLength < maxRespSize) {
+			//Only title match HTML files. Prevents expensive regex running on e.g. binary downloads.
+			if (this.responseInferredMimeType.equalsIgnoreCase("HTML")) {
+				String strFullResponse = new String(requestResponse.getResponse());
+				Matcher titleMatcher = Globals.HTML_TITLE_PATTERN.matcher(strFullResponse);
+				if (titleMatcher.find()) {
+					this.title = titleMatcher.group(1);
+				}
+			}
+
+			int bodyOffset = requestResponse.getResponse().length - responseBodyLength;
+			if (responseBodyLength > 0) {
+				String responseBody = new String(requestResponse.getResponse(), bodyOffset, responseBodyLength);
+				ReflectionController reflectionController = LoggerPlusPlus.instance.getReflectionController();
+				reflectedParameters = tempParameters.parallelStream()
+						.filter(iParameter -> !reflectionController.isParameterFiltered(iParameter)
+								&& reflectionController.validReflection(responseBody, iParameter))
+						.map(IParameter::getName).collect(Collectors.toList());
+			}
+
+			this.requestResponse = LoggerPlusPlus.callbacks.saveBuffersToTempFiles(requestResponse);
+		} else {
+			//Trim the response down to a maximum size, but at least keep the headers!
+			//Then save the buffers to temp files
+			//And finally restore the original body to the original IHttpRequestResponse object so we don't modify the content sent to the browser.
+			IHttpRequestResponse original = this.requestResponse;
+			byte[] originalResponse = this.requestResponse.getResponse();
+			requestResponse.setResponse((new String(this.requestResponse.getResponse(), 0, requestResponse.getResponse().length - responseBodyLength) + "Response body trimmed by Logger++. To prevent this, increase \"Maximum Response Size\" in the Logger++ options.").getBytes(StandardCharsets.UTF_8));
+			this.requestResponse = LoggerPlusPlus.callbacks.saveBuffersToTempFiles(requestResponse);
+			original.setResponse(originalResponse);
+		}
+
+
+		tempParameters = null; // We're done with these. Allow them to be cleaned.
 
 		this.complete = true;
 
@@ -505,7 +539,7 @@ public class LogEntry {
 				case MIME_TYPE:
 					return this.responseMimeType;
 				case RESPONSE_LENGTH:
-					return this.responseLength;
+					return this.responseBodyLength;
 				case PORT:
 					return this.targetPort;
 				case METHOD:
@@ -535,7 +569,7 @@ public class LogEntry {
 				case HASCOOKIEPARAM:
 					return this.hasCookieParam;
 				case REQUEST_LENGTH:
-					return this.requestLength;
+					return this.requestBodyLength;
 				case RESPONSE_CONTENT_TYPE:
 					return this.responseContentType;
 				case INFERRED_TYPE:
@@ -585,11 +619,13 @@ public class LogEntry {
 				case REFLECTION_COUNT:
 					return reflectedParameters.size();
 				case REQUEST_BODY: // request
-					return new String(requestResponse.getRequest())
-							.substring(requestResponse.getRequest().length - requestLength);
+					if (requestBodyLength == 0) return "";
+					return new String(requestResponse.getRequest(), requestResponse.getRequest().length - requestBodyLength, requestBodyLength);
+//							.substring(requestResponse.getRequest().length - requestBodyLength);
 				case RESPONSE_BODY: // response
-					return new String(requestResponse.getResponse())
-							.substring(requestResponse.getResponse().length - responseLength);
+					if (responseBodyLength == 0) return "";
+					return new String(requestResponse.getResponse(), requestResponse.getResponse().length - responseBodyLength, responseBodyLength);
+//							.substring(requestResponse.getResponse().length - responseBodyLength);
 				case RTT:
 					return requestResponseDelay;
 				case REQUEST_HEADERS:

--- a/src/main/java/com/nccgroup/loggerplusplus/preferences/LoggerPreferenceFactory.java
+++ b/src/main/java/com/nccgroup/loggerplusplus/preferences/LoggerPreferenceFactory.java
@@ -73,6 +73,7 @@ public class LoggerPreferenceFactory extends PreferenceFactory {
         prefs.registerSetting(PREF_LOG_SEQUENCER, Boolean.class, true);
         prefs.registerSetting(PREF_LOG_EXTENDER, Boolean.class, true);
         prefs.registerSetting(PREF_LOG_TARGET_TAB, Boolean.class, true);
+        prefs.registerSetting(PREF_MAX_RESP_SIZE, Integer.class, 10); //Default 10MB
         prefs.registerSetting(PREF_COLOR_FILTERS, new TypeToken<Map<UUID, ColorFilter>>() {
         }.getType(), defaultColorFilters);
         prefs.registerSetting(PREF_TAG_FILTERS, new TypeToken<Map<UUID, Tag>>() {

--- a/src/main/java/com/nccgroup/loggerplusplus/preferences/PreferencesPanel.java
+++ b/src/main/java/com/nccgroup/loggerplusplus/preferences/PreferencesPanel.java
@@ -202,6 +202,12 @@ public class PreferencesPanel extends JScrollPane {
         ((SpinnerNumberModel) spnSearchThreads.getModel()).setMaximum(50);
         ((SpinnerNumberModel) spnSearchThreads.getModel()).setStepSize(1);
 
+        JSpinner maxResponseSize = otherPanel.addPreferenceComponent(preferences, PREF_MAX_RESP_SIZE,
+                "Maximum Response Size (MB): ");
+        ((SpinnerNumberModel) maxResponseSize.getModel()).setMinimum(0);
+        ((SpinnerNumberModel) maxResponseSize.getModel()).setMaximum(1000000);
+        ((SpinnerNumberModel) maxResponseSize.getModel()).setStepSize(1);
+
         ComponentGroup savedFilterSharing = new ComponentGroup(Orientation.VERTICAL, "Saved Filter Sharing");
         savedFilterSharing.add(new JButton(new AbstractAction("Import Saved Filters") {
             @Override

--- a/src/main/java/com/nccgroup/loggerplusplus/util/Globals.java
+++ b/src/main/java/com/nccgroup/loggerplusplus/util/Globals.java
@@ -72,6 +72,7 @@ public class Globals {
     public static final String PREF_PREVIOUS_ELASTIC_FIELDS = "previousElasticFields";
     public static final String PREF_SAVED_FIELD_SELECTIONS = "savedFieldSelections";
     public static final String PREF_COLUMNS_VERSION = "columnsVersion";
+    public static final String PREF_MAX_RESP_SIZE = "maxRespBodySize";
 
     public enum ElasticAuthType {ApiKey, Basic, None}
 


### PR DESCRIPTION
Closes #42 .

Since `processProxyMessage` occurs after `processHttpMessage`, requests originating from the proxy "tool" have their responses obtained in the `processProxyMessage` method rather than `processHttpMessage`. This should ensure proxy messages modified by other extensions within the `processProxyMessage` method are seen by Logger++.