### PR TITLE
2022 bugfixes

### DIFF
--- a/src/main/java/com/nccgroup/loggerplusplus/logview/entryviewer/RequestViewerController.java
+++ b/src/main/java/com/nccgroup/loggerplusplus/logview/entryviewer/RequestViewerController.java
@@ -24,6 +24,9 @@ public class RequestViewerController implements IMessageEditorController {
     }
 
     public void setDisplayedEntity(LogEntry logEntry) {
+        // Only update message if it's new. This fixes issue #164 and improves performance during heavy scanning.
+        if (this.currentEntry == logEntry) { return; }
+
         this.currentEntry = logEntry;
 
         if (logEntry.getRequest() != null) {


### PR DESCRIPTION
This PR fixes a couple of bugs introduced by recent burp suite updates.

### Missing JMenu

The old style of finding the root burp JFrame no longer works, so the Logger++ JMenu was not being added. This effectively prevented users from using the pop in/pop out functionality.  This new method searches for the root pane by the title, but there are other more sophisticated methods available such as [this](https://github.com/mdsecresearch/BurpSuiteSharpener/commit/6587e8c5580928de3f79979757a17cfdaabbaaf9).

### Request Viewer Performance

Also fixes issue #164, where excessive updates to the request viewer to perform poorly