### PR TITLE
retain fields when import from JSON

### DIFF
--- a/src/main/java/com/nccgroup/loggerplusplus/LoggerPlusPlus.java
+++ b/src/main/java/com/nccgroup/loggerplusplus/LoggerPlusPlus.java
@@ -14,6 +14,7 @@ import com.nccgroup.loggerplusplus.logview.LogViewController;
 import com.nccgroup.loggerplusplus.logview.processor.LogProcessor;
 import com.nccgroup.loggerplusplus.preferences.PreferencesController;
 import com.nccgroup.loggerplusplus.reflection.ReflectionController;
+import com.nccgroup.loggerplusplus.util.DateFormattedGsonProvider;
 import com.nccgroup.loggerplusplus.util.Globals;
 import com.nccgroup.loggerplusplus.util.userinterface.LoggerMenu;
 import lombok.Getter;
@@ -39,7 +40,7 @@ public class LoggerPlusPlus implements BurpExtension {
     public static LoggingController loggingController;
     public static LoggerPlusPlus instance;
     public static MontoyaApi montoya;
-    public static IGsonProvider gsonProvider = new DefaultGsonProvider();
+    public static IGsonProvider gsonProvider = new DateFormattedGsonProvider();
 
     private Registration menuBarRegistration;
     private LogProcessor logProcessor;

--- a/src/main/java/com/nccgroup/loggerplusplus/logentry/ImportingLogEntryHttpRequestResponse.java
+++ b/src/main/java/com/nccgroup/loggerplusplus/logentry/ImportingLogEntryHttpRequestResponse.java
@@ -1,0 +1,71 @@
+package com.nccgroup.loggerplusplus.logentry;
+
+import burp.api.montoya.core.ToolType;
+import burp.api.montoya.http.message.HttpRequestResponse;
+import burp.api.montoya.http.message.requests.HttpRequest;
+import burp.api.montoya.http.message.responses.HttpResponse;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.log4j.Log4j2;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+@Getter
+@Log4j2
+public class ImportingLogEntryHttpRequestResponse {
+    // example: Nov 15, 2023, 6:30:46 PM
+    // ...btw wt is this date time format, it is not common at all!
+    // ...ffs, there is also a '0x202f' (Narrow no-break space) char in the date sometime..
+    private static final SimpleDateFormat dtFormatter = new SimpleDateFormat("MMM d, y, K:m:s a");
+
+    private final HttpRequestResponse httpReqRes;
+
+    private Date requestTime = null;
+
+    private Date responseTime = null;
+
+    @Setter
+    private String comment = null;
+
+    private ToolType tool = null;
+
+    public ImportingLogEntryHttpRequestResponse(HttpRequestResponse hrr) {
+        this.httpReqRes = hrr;
+    }
+
+    public HttpRequest request() {
+        return httpReqRes.request();
+    }
+
+    public HttpResponse response() {
+        return httpReqRes.response();
+    }
+
+    public void setRequestTime(String dateTimeString) {
+        try {
+            this.requestTime = dtFormatter.parse(dateTimeString.replace('\u202F', ' '));
+        } catch (ParseException e) {
+            log.error("Failed to parse requestTime: " + dateTimeString);
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void setResponseTime(String dateTimeString) {
+        try {
+            this.responseTime = dtFormatter.parse(dateTimeString.replace('\u202F', ' '));
+        } catch (ParseException e) {
+            log.error("Failed to parse responseTime: " + dateTimeString);
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void setTool(String toolName) {
+        try {
+            this.tool = ToolType.valueOf(toolName.toUpperCase());
+        } catch (Exception e) {
+            log.error("Error at setTool: " + toolName);
+        }
+    }
+}

--- a/src/main/java/com/nccgroup/loggerplusplus/logentry/ImportingLogEntryHttpRequestResponse.java
+++ b/src/main/java/com/nccgroup/loggerplusplus/logentry/ImportingLogEntryHttpRequestResponse.java
@@ -19,6 +19,7 @@ public class ImportingLogEntryHttpRequestResponse {
     // ...btw wt is this date time format, it is not common at all!
     // ...ffs, there is also a '0x202f' (Narrow no-break space) char in the date sometime..
     private static final SimpleDateFormat dtFormatter = new SimpleDateFormat("MMM d, y, K:m:s a");
+    private static final SimpleDateFormat longDtFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 
     private final HttpRequestResponse httpReqRes;
 
@@ -27,9 +28,15 @@ public class ImportingLogEntryHttpRequestResponse {
     private Date responseTime = null;
 
     @Setter
+    private Integer RTT = null;
+
+    @Setter
     private String comment = null;
 
     private ToolType tool = null;
+
+    @Setter
+    private String listenInterface = null;
 
     public ImportingLogEntryHttpRequestResponse(HttpRequestResponse hrr) {
         this.httpReqRes = hrr;
@@ -43,9 +50,17 @@ public class ImportingLogEntryHttpRequestResponse {
         return httpReqRes.response();
     }
 
+    private Date formattedTimeParser(String dateTimeString) throws ParseException {
+        if (dateTimeString.indexOf(',') > -1)
+        {
+            return dtFormatter.parse(dateTimeString.replace('\u202F', ' '));
+        }
+        return longDtFormatter.parse(dateTimeString);
+    }
+
     public void setRequestTime(String dateTimeString) {
         try {
-            this.requestTime = dtFormatter.parse(dateTimeString.replace('\u202F', ' '));
+            this.requestTime = formattedTimeParser(dateTimeString);
         } catch (ParseException e) {
             log.error("Failed to parse requestTime: " + dateTimeString);
             throw new RuntimeException(e);
@@ -54,7 +69,7 @@ public class ImportingLogEntryHttpRequestResponse {
 
     public void setResponseTime(String dateTimeString) {
         try {
-            this.responseTime = dtFormatter.parse(dateTimeString.replace('\u202F', ' '));
+            this.responseTime = formattedTimeParser(dateTimeString);
         } catch (ParseException e) {
             log.error("Failed to parse responseTime: " + dateTimeString);
             throw new RuntimeException(e);

--- a/src/main/java/com/nccgroup/loggerplusplus/logentry/LogEntry.java
+++ b/src/main/java/com/nccgroup/loggerplusplus/logentry/LogEntry.java
@@ -132,7 +132,7 @@ public class LogEntry {
 	 */
 	public LogEntry(ToolType tool, HttpRequest request, Date formattedRequestTime) {
 		this(tool, request);
-		this.setReqestTime(formattedRequestTime);
+		this.setRequestTime(formattedRequestTime);
 	}
 
 	public boolean process() {
@@ -388,7 +388,7 @@ public class LogEntry {
 		return response.toByteArray().getBytes();
 	}
 
-	public void setReqestTime(Date requestTime) {
+	public void setRequestTime(Date requestTime) {
 		this.requestDateTime = requestTime;
 		this.formattedRequestTime = LogProcessor.LOGGER_DATE_FORMAT.format(this.requestDateTime);
 	}

--- a/src/main/java/com/nccgroup/loggerplusplus/preferences/PreferencesPanel.java
+++ b/src/main/java/com/nccgroup/loggerplusplus/preferences/PreferencesPanel.java
@@ -27,6 +27,7 @@ import com.nccgroup.loggerplusplus.filter.parser.ParseException;
 import com.nccgroup.loggerplusplus.filter.savedfilter.SavedFilter;
 import com.nccgroup.loggerplusplus.filter.tag.Tag;
 import com.nccgroup.loggerplusplus.imports.LoggerImport;
+import com.nccgroup.loggerplusplus.logentry.ImportingLogEntryHttpRequestResponse;
 import com.nccgroup.loggerplusplus.logentry.LogEntryField;
 import com.nccgroup.loggerplusplus.logview.logtable.LogTableColumn;
 import com.nccgroup.loggerplusplus.logview.logtable.LogTableColumnModel;
@@ -186,7 +187,7 @@ public class PreferencesPanel extends JScrollPane {
         importGroup.add(new JButton(new AbstractAction("Import From WStalker CSV") {
             @Override
             public void actionPerformed(ActionEvent e) {
-                ArrayList<HttpRequestResponse> requests = LoggerImport.importWStalker();
+                ArrayList<ImportingLogEntryHttpRequestResponse> requests = LoggerImport.importWStalker();
                 if (LoggerPlusPlus.instance.getExportController().getEnabledExporters().size() > 0) {
                     int res = JOptionPane.showConfirmDialog(LoggerPlusPlus.instance.getLoggerFrame(),
                             "One or more auto-exporters are currently enabled. " +
@@ -202,7 +203,7 @@ public class PreferencesPanel extends JScrollPane {
         importGroup.add(new JButton(new AbstractAction("Import From OWASP ZAP") {
             @Override
             public void actionPerformed(ActionEvent e) {
-                ArrayList<HttpRequestResponse> requests;
+                ArrayList<ImportingLogEntryHttpRequestResponse> requests;
                 try{
                     requests = LoggerImport.importZAP();
                 } catch (Exception ex){
@@ -227,7 +228,7 @@ public class PreferencesPanel extends JScrollPane {
         importGroup.add(new JButton(new AbstractAction("Import From Exported JSON") {
             @Override
             public void actionPerformed(ActionEvent e) {
-                ArrayList<HttpRequestResponse> requests = LoggerImport.importFromExportedJson();
+                ArrayList<ImportingLogEntryHttpRequestResponse> requests = LoggerImport.importFromExportedJson();
                 if (LoggerPlusPlus.instance.getExportController().getEnabledExporters().size() > 0) {
                     int res = JOptionPane.showConfirmDialog(LoggerPlusPlus.instance.getLoggerFrame(),
                             "One or more auto-exporters are currently enabled. " +

--- a/src/main/java/com/nccgroup/loggerplusplus/util/Globals.java
+++ b/src/main/java/com/nccgroup/loggerplusplus/util/Globals.java
@@ -8,7 +8,7 @@ import static com.nccgroup.loggerplusplus.logentry.LogEntryField.*;
 
 public class Globals {
     public static final String APP_NAME = "Logger++";
-    public static final String VERSION = "3.20.1";
+    public static final String VERSION = "3.21.1";
     public static final String AUTHOR = "Corey Arthur (@CoreyD97), Soroush Dalili (@irsdl) from NCC Group";
     public static final String TWITTER_URL = "https://twitter.com/CoreyD97";
     public static final String IRSDL_TWITTER_URL = "https://twitter.com/irsdl";


### PR DESCRIPTION
updates:
1. export JSON with new date format (`yyyy-MM-dd HH:mm:ss`) (original: `MMM d, y, K:m:s a`)
2. import JSON with original entry fields:
    1. tool name
    2. comment
    3. request date time
    4. response date time
    5. RTT (request response delay)
    6. listen interface
3. and finally, fixed a typo

version number updated from 3.20.1 to 3.21.1